### PR TITLE
feat: migrate to new swift syntax repo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/apple/swift-syntax",
+            url: "https://github.com/swiftlang/swift-syntax",
             exact: "509.0.0"
         )
     ],


### PR DESCRIPTION
Migrated from deprecated Apple repo to official Swift repo as Apple delegated it away this year